### PR TITLE
fixed a bug related to extracting information from mecab result.

### DIFF
--- a/mlask/mlask.py
+++ b/mlask/mlask.py
@@ -60,6 +60,8 @@ class MLAsk(object):
             mecab_arg = mecab_arg.encode('utf8')
         self.mecab = MeCab.Tagger(mecab_arg)
         self._read_emodic()
+        if not PY2:
+            self.mecab.parse('')
 
     def _read_emodic(self):
         """ Load emotion dictionaries """
@@ -145,13 +147,18 @@ class MLAsk(object):
                     features = node.feature.split(',')
                 if len(features) > 7:
                     (pos, subpos, lemma) = features[0], features[1], features[6]
+                elif len(features) == 1:
+                    pos = None
+                    subpos = None
+                    lemma = None
                 else:
                     (pos, subpos, lemma) = features[0], features[1], surface
-                lemmas['all'].append(lemma)
-                if RE_POS.search(pos + subpos) or RE_MIDAS.search(surface):
-                    lemmas['interjections'].append(surface)
-                else:
-                    lemmas['no_emotem'].append(surface)
+                if not pos is None and not subpos is None and not lemma is None:
+                    lemmas['all'].append(lemma)
+                    if RE_POS.search(pos + subpos) or RE_MIDAS.search(surface):
+                        lemmas['interjections'].append(surface)
+                    else:
+                        lemmas['no_emotem'].append(surface)
             except UnicodeDecodeError:
                 pass
             node = node.next


### PR DESCRIPTION
Python2.x/Python3.xの両方でエラーが実行エラーが出てしまうので、修正しました。

# Python2.x/Python3.x共通エラー

`_lexical_analysis()` 内部で、mecabの解析結果を取得する部分。
記号 `(` のfeatureが1つしか存在しない。
なので、features要素を足りなくて、エラーになる。

## 対処

featureが1つしかない場合のルールを追加

# Python3.xエラー

nodeオブジェクトからsurface要素を獲得できない。[参考情報](http://qiita.com/piruty_joy/items/ce218090eae53b775b79)

## 対処

`__init__()` 内部に `self.mecab.parse('')` を記述


# 以下の環境で検証しました

- Mac OS 10.11.6
- Mecab 0.996
- Python
    - Python2.x: 2.7.11
    - Python3.x: 3.5.2





