### PR TITLE
Fix the count of emotional words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 *.bak
 .DS_Store
 .coverage
+.cache

--- a/mlask/mlask.py
+++ b/mlask/mlask.py
@@ -228,9 +228,9 @@ class MLAsk(object):
     def _find_emotion(self, lemmas):
         """ Finding emotion word by dictionaries """
 
-        # Build all sentences comprised of words from the text (max number of words = 5)
+        # Build all sentences comprised of words from the text (max number of words = 7)
         total_length = len(lemmas['lemma_words'])
-        sentences = [''.join(lemmas['lemma_words'][i:j+1]) for i in range(total_length) for j in range(i, i + 5 if i + 5 <= total_length else total_length)]
+        sentences = [''.join(lemmas['lemma_words'][i:j+1]) for i in range(total_length) for j in range(i, i + 7 if i + 7 <= total_length else total_length)]
         text_sentences = set(sentences)
         found_emotions = collections.defaultdict(list)
         for emotion_class, emotions in self.emodic['emotion'].items():

--- a/mlask/mlask.py
+++ b/mlask/mlask.py
@@ -227,11 +227,15 @@ class MLAsk(object):
 
     def _find_emotion(self, lemmas):
         """ Finding emotion word by dictionaries """
-        text_lemmas = set(lemmas['lemma_words'])
+
+        # Build all sentences comprised of words from the text (max number of words = 5)
+        total_length = len(lemmas['lemma_words'])
+        sentences = [''.join(lemmas['lemma_words'][i:j+1]) for i in range(total_length) for j in range(i, i + 5 if i + 5 <= total_length else total_length)]
+        text_sentences = set(sentences)
         found_emotions = collections.defaultdict(list)
         for emotion_class, emotions in self.emodic['emotion'].items():
             for emotion in emotions:
-                if emotion not in text_lemmas:
+                if emotion not in text_sentences:
                     continue
                 cvs_regex = re.compile('%s(?:%s(%s))' % (emotion, RE_PARTICLES, RE_CVS))
                 # if there is Contextual Valence Shifters

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -38,12 +38,13 @@ def test__find_emotion():
     assert_equals(mla._find_emotion(lemmas_with_interjections), {'iya': ['嫌い']})
     empty_lemmas = {'all': [], 'interjections': [], 'no_emotem': [], 'lemma_words': []}
     assert_equals(mla._find_emotion(empty_lemmas), None)
+    lemmas = {'all': '気持ちがよい', 'lemma_words': ['気持ち', 'が', 'よい']}
+    assert_equals(mla._find_emotion(lemmas), {'yorokobi': ['気持ちがよい']})
 
 def test__estimate_sentiment_orientation():
     assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
     assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS']}), 'POSITIVE')
     assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS'], 'iya': ['嫌い']}), 'NEUTRAL')
-    assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS'], 'suki': ['嫌い*CVS'], 'iya': ['嫌い']}), 'mostly_POSITIVE')
 
 def test__estimate_activation():
     assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -19,7 +19,7 @@ def test__normalize():
 
 def test__lexical_analysis():
     assert_equals(mla._lexical_analysis('すごい'),
-                  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい'})
+                  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい', 'lemma_words': ['すごい']})
 
 def test__find_emoticon():
     assert_equals(mla._find_emoticon('(;´Д`)'), ['(;´Д`)'])
@@ -30,7 +30,8 @@ def test__find_emotem():
                   {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
 
 def test__find_emotion():
-    assert_equals(mla._find_emotion('嫌い'), {'iya': ['嫌', '嫌い']})
+	lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
+	assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
 
 def test__estimate_sentiment_orientation():
     assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -12,6 +12,8 @@ def test__read_emodic():
 def test_analyze():
     result = mla.analyze('彼は嫌いではない！(;´Д`)')
     assert_equals(result['text'], '彼は嫌いではない！(;´Д`)')
+    result = mla.analyze('')
+    assert_equals(result, {'text': '', 'emotion': None})
 
 def test__normalize():
     assert_equals(mla._normalize('!'), '！')
@@ -32,9 +34,16 @@ def test__find_emotem():
 def test__find_emotion():
     lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
     assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
+    lemmas_with_interjections = {'all': 'え！嫌い', 'interjections': ['え'], 'lemma_words': ['え','！', '嫌い']}
+    assert_equals(mla._find_emotion(lemmas_with_interjections), {'iya': ['嫌い']})
+    empty_lemmas = {'all': [], 'interjections': [], 'no_emotem': [], 'lemma_words': []}
+    assert_equals(mla._find_emotion(empty_lemmas), None)
 
 def test__estimate_sentiment_orientation():
     assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
+    assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS']}), 'POSITIVE')
+    assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS'], 'iya': ['嫌い']}), 'NEUTRAL')
+    assert_equals(mla._estimate_sentiment_orientation({'yorokobi': ['嫌い*CVS'], 'suki': ['嫌い*CVS'], 'iya': ['嫌い']}), 'mostly_POSITIVE')
 
 def test__estimate_activation():
     assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -6,38 +6,38 @@ from mlask import MLAsk
 mla = MLAsk()
 
 def test__read_emodic():
-    assert_true('！' in mla.emodic['emotem']['exclamation'])
-    assert_true('嫌い' in mla.emodic['emotion']['iya'])
+	assert_true('！' in mla.emodic['emotem']['exclamation'])
+	assert_true('嫌い' in mla.emodic['emotion']['iya'])
 
 def test_analyze():
-    result = mla.analyze('彼は嫌いではない！(;´Д`)')
-    assert_equals(result['text'], '彼は嫌いではない！(;´Д`)')
+	result = mla.analyze('彼は嫌いではない！(;´Д`)')
+	assert_equals(result['text'], '彼は嫌いではない！(;´Д`)')
 
 def test__normalize():
-    assert_equals(mla._normalize('!'), '！')
-    assert_equals(mla._normalize('?'), '？')
+	assert_equals(mla._normalize('!'), '！')
+	assert_equals(mla._normalize('?'), '？')
 
 def test__lexical_analysis():
-    assert_equals(mla._lexical_analysis('すごい'),
-                  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい', 'lemma_words': ['すごい']})
+	assert_equals(mla._lexical_analysis('すごい'),
+				  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい', 'lemma_words': ['すごい']})
 
 def test__find_emoticon():
-    assert_equals(mla._find_emoticon('(;´Д`)'), ['(;´Д`)'])
-    assert_equals(mla._find_emoticon('顔文字なし'), [])
+	assert_equals(mla._find_emoticon('(;´Д`)'), ['(;´Д`)'])
+	assert_equals(mla._find_emoticon('顔文字なし'), [])
 
 def test__find_emotem():
-    assert_equals(mla._find_emotem({'no_emotem': '(;´Д`)', 'interjections': '！'}, []),
-                  {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
+	assert_equals(mla._find_emotem({'no_emotem': '(;´Д`)', 'interjections': '！'}, []),
+				  {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
 
 def test__find_emotion():
 	lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
 	assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
 
 def test__estimate_sentiment_orientation():
-    assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
+	assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
 
 def test__estimate_activation():
-    assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')
+	assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')
 
 def test__get_representative_emotion():
-    assert_equals(mla._get_representative_emotion({'iya': ['嫌い', '嫌']}), ('iya', ['嫌い', '嫌']))
+	assert_equals(mla._get_representative_emotion({'iya': ['嫌い', '嫌']}), ('iya', ['嫌い', '嫌']))

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -6,38 +6,38 @@ from mlask import MLAsk
 mla = MLAsk()
 
 def test__read_emodic():
-	assert_true('！' in mla.emodic['emotem']['exclamation'])
-	assert_true('嫌い' in mla.emodic['emotion']['iya'])
+    assert_true('！' in mla.emodic['emotem']['exclamation'])
+    assert_true('嫌い' in mla.emodic['emotion']['iya'])
 
 def test_analyze():
-	result = mla.analyze('彼は嫌いではない！(;´Д`)')
-	assert_equals(result['text'], '彼は嫌いではない！(;´Д`)')
+    result = mla.analyze('彼は嫌いではない！(;´Д`)')
+    assert_equals(result['text'], '彼は嫌いではない！(;´Д`)')
 
 def test__normalize():
-	assert_equals(mla._normalize('!'), '！')
-	assert_equals(mla._normalize('?'), '？')
+    assert_equals(mla._normalize('!'), '！')
+    assert_equals(mla._normalize('?'), '？')
 
 def test__lexical_analysis():
-	assert_equals(mla._lexical_analysis('すごい'),
-				  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい', 'lemma_words': ['すごい']})
+    assert_equals(mla._lexical_analysis('すごい'),
+                  {'all': 'すごい', 'interjections': [], 'no_emotem': 'すごい', 'lemma_words': ['すごい']})
 
 def test__find_emoticon():
-	assert_equals(mla._find_emoticon('(;´Д`)'), ['(;´Д`)'])
-	assert_equals(mla._find_emoticon('顔文字なし'), [])
+    assert_equals(mla._find_emoticon('(;´Д`)'), ['(;´Д`)'])
+    assert_equals(mla._find_emoticon('顔文字なし'), [])
 
 def test__find_emotem():
-	assert_equals(mla._find_emotem({'no_emotem': '(;´Д`)', 'interjections': '！'}, []),
-				  {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
+    assert_equals(mla._find_emotem({'no_emotem': '(;´Д`)', 'interjections': '！'}, []),
+                  {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
 
 def test__find_emotion():
     lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
     assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
 
 def test__estimate_sentiment_orientation():
-	assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
+    assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')
 
 def test__estimate_activation():
-	assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')
+    assert_equals(mla._estimate_activation({'iya': ['嫌い', '嫌']}), 'ACTIVE')
 
 def test__get_representative_emotion():
-	assert_equals(mla._get_representative_emotion({'iya': ['嫌い', '嫌']}), ('iya', ['嫌い', '嫌']))
+    assert_equals(mla._get_representative_emotion({'iya': ['嫌い', '嫌']}), ('iya', ['嫌い', '嫌']))

--- a/test_mlask.py
+++ b/test_mlask.py
@@ -30,8 +30,8 @@ def test__find_emotem():
                   {'emotikony': ['´Д`', 'Д`', '´Д'], 'interjections': ['！']})
 
 def test__find_emotion():
-	lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
-	assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
+    lemmas = {'all': '嫌い', 'lemma_words': ['嫌い']}
+    assert_equals(mla._find_emotion(lemmas), {'iya': ['嫌い']})
 
 def test__estimate_sentiment_orientation():
     assert_equals(mla._estimate_sentiment_orientation({'iya': ['嫌い', '嫌']}), 'NEGATIVE')


### PR DESCRIPTION
**Problem**
The method `_find_emotion` was counting emotional words by searching each word against the entire text, therefore, an existing emotional word would be counted not only by itself but by all words that is included inside itself. Example:
```python
from mlask import MLAsk

ma = MLAsk()
ma.analyze('嫌いではない')     # Incorrect => {'iya': ['嫌'], 'yorokobi': ['嫌い*CVS'], 'suki': ['嫌い*CVS']}
ma.analyze('嫌ではない')      # Correct => {'yorokobi': ['嫌*CVS'], 'suki': ['嫌*CVS']}
```
In this example, the text `嫌いではない` contains only the emotional word `嫌い`, however, both words `嫌い` and `嫌` are being counted because `嫌` is also included inside the word `嫌い`.

**Resolution**
The method `_find_emotion` should search each emotional word from the dictionary by matching it with each lemma found in the text, that is, compare word by word instead of word inside the text.
The expected result should be:
```python
from mlask import MLAsk

ma = MLAsk()
ma.analyze('嫌いではない')     # Correct => {'yorokobi': ['嫌い*CVS'], 'suki': ['嫌い*CVS']}
ma.analyze('嫌ではない')      # Correct => {'yorokobi': ['嫌*CVS'], 'suki': ['嫌*CVS']}
```